### PR TITLE
Improve reaction time accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </ul>
 
 <h2><u>The Algorithm Used to get Reaction Speed</u></h2>
-<p>Your score should be accurate because the algorithm is that every time a new color is generated, a start date object is created, and when you click the board, an end date object is made, and then I simply get the difference between the two dates and display it in milliseconds. This works much better than relying on setInterval/setTimeout/requestAnimationFrame as those methods are not 100% consistent.</p>
+<p>Your score should be accurate because the algorithm is that every time a new color is generated, a start time is recorded using the browser's <code>performance.now()</code> API, and when you click the board we capture another timestamp. The difference between these high&#x2011;resolution times is displayed in milliseconds, providing more precise results than the older <code>Date</code> approach.</p>
 
 <h2><u>How this App Looks</u></h2>
 <p>This app may look "ugly" to some as I'm not a designer, but this isn't about making it look good, it's about the core functionality.</p>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <h2><u>Potential Future Update Notes</u></h2>
 <ul>
-    <li>Line chart of attemtps</li>
+    <li>Line chart of attempts</li>
     <li>User accounts - Doing this allows for many more features like tracking reaction speed over a longer period of time.</li>
 </ul>
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ let hasNotClickedGreen = false;
 let changeBoardColorIntervalID = null;
 let scoreList = [];
 let genreatedColors = [];
-let startDate = null;
-let endDate = null;
+let startTime = null;
+let endTime = null;
 let count = 0;
 let randomTickRate = getRandomTickRate();
 
@@ -46,8 +46,8 @@ function getRandomTickRate() {
 }
 
 function changeBoardColor() {
-    startDate = 0;
-    endDate = 0;
+    startTime = 0;
+    endTime = 0;
     
     changeBoardColorIntervalID = setInterval(() => {
         score = 0;
@@ -79,7 +79,7 @@ function changeBoardColor() {
             
             board.style.backgroundColor = randomColor;
             
-            startDate = +new Date();
+            startTime = performance.now();
 
             if (isBoardGreen()) {
                 ding().play();
@@ -116,7 +116,8 @@ function clickedGameBoard(event) {
 
     event.stopImmediatePropagation();
 
-    score = (+new Date() - startDate);
+    score = (performance.now() - startTime);
+    endTime = performance.now();
 
     clearInterval(changeBoardColorIntervalID);
 
@@ -195,8 +196,8 @@ function resetGame(event) {
     // reset game state
     score = 0;
     count = 0;
-    endDate = 0;
-    startDate = 0;
+    endTime = 0;
+    startTime = 0;
     gameStarted = false;
     hasClickedGreen = false;
     hasNotClickedGreen = false;

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ let hasClickedGreen = false;
 let hasNotClickedGreen = false;
 let changeBoardColorIntervalID = null;
 let scoreList = [];
-let genreatedColors = [];
+let generatedColors = [];
 let startTime = null;
 let endTime = null;
 let count = 0;
@@ -59,9 +59,9 @@ function changeBoardColor() {
         if (gameStarted) {
             let randomColor = getRandomColor();
 
-            genreatedColors.push(randomColor);
+            generatedColors.push(randomColor);
 
-            if (genreatedColors.length === 1 && isBoardGreen()) {
+            if (generatedColors.length === 1 && isBoardGreen()) {
                 randomColor = getRandomColor();
             }
 
@@ -75,7 +75,7 @@ function changeBoardColor() {
                 randomColor = 'green';
             }
 
-            genreatedColors.push(randomColor);
+            generatedColors.push(randomColor);
             
             board.style.backgroundColor = randomColor;
             
@@ -89,7 +89,7 @@ function changeBoardColor() {
 }
 
 function isInteractionTooEarly() {
-    if (!genreatedColors.length ) {
+    if (!generatedColors.length ) {
         return true;
     }
 
@@ -171,7 +171,7 @@ function clickedGameBoard(event) {
 function resetGame(event) {
     event.stopImmediatePropagation();
 
-    genreatedColors = [];
+    generatedColors = [];
 
     // if score list has 5 entries, reset score list, remove all li elements from score list div, and remove average score text from evaluation div
     if (scoreList.length === 5) {


### PR DESCRIPTION
## Summary
- rename internal timing variables
- use `performance.now()` for more precise reaction time calculations
- document new high-resolution timing approach in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a3519b6748321b70e7b531004cf40